### PR TITLE
Add a control message for the run dialog.

### DIFF
--- a/src/smenu.c
+++ b/src/smenu.c
@@ -951,6 +951,11 @@ gboolean menu_control_msg (MenuPlugin *m, const char *cmd)
         }
         return TRUE;
     }
+    if (!strncmp (cmd, "run", 3))
+    {
+        gtk_run ();
+        return TRUE;
+    }
 
     return FALSE;
 }


### PR DESCRIPTION
When running `wf-panel-pi`, this lets a run dialog be activated using `wfpanelctl smenu run`. This is for instance useful for supporting the Alt-F2 keybinding from the X-based Raspberry Pi desktop environment [1] also in the Wayland-based Raspberry Pi desktop environment [2].

[1] https://github.com/raspberrypi-ui/rpd-metas/blob/1e0203bb6ecb9ecb16853c7e3d66897192c0e79c/x/etc/xdg/openbox/rpd-rc.xml#L269-L273 \
[2] https://github.com/raspberrypi-ui/rpd-metas/blob/1e0203bb6ecb9ecb16853c7e3d66897192c0e79c/wayland/etc/xdg/labwc/rc.xml#L32

On the `lxpanel-pi` side, the same run dialog can be activated using `lxpanelctl-pi command smenu run`, though that is redundant with `lxpanelctl-pi run`.

---

I hope this patch is simple enough to be considered, despite adding a feature instead of addressing a demonstrated bug.