### PR TITLE
wfplug-menu: Handle Return key for top-level items and subsubmenu items.

### DIFF
--- a/src/smenu.c
+++ b/src/smenu.c
@@ -531,17 +531,18 @@ static gboolean handle_key_presses (GtkWidget *, GdkEventKey *event, gpointer us
 #else
     if (event->keyval == GDK_KEY_Return)
     {
-        GtkWidget *menu = gtk_menu_shell_get_selected_item (GTK_MENU_SHELL (m->menu));
-        GtkWidget *submenu = gtk_menu_item_get_submenu (GTK_MENU_ITEM (menu));
-        if (submenu)
+        GtkWidget *item = gtk_menu_shell_get_selected_item (GTK_MENU_SHELL (m->menu));
+        while (item)
         {
-            GtkWidget *subitem = gtk_menu_shell_get_selected_item (GTK_MENU_SHELL (submenu));
-            if (subitem)
-            {
-                handle_menu_item_activate (GTK_MENU_ITEM (subitem), m);
-                destroy_menu (m);
-                return TRUE;
-            }
+            GtkWidget *submenu = gtk_menu_item_get_submenu (GTK_MENU_ITEM (item));
+            if (!submenu) break;
+            item = gtk_menu_shell_get_selected_item (GTK_MENU_SHELL (submenu));
+        }
+        if (item)
+        {
+            handle_menu_item_activate (GTK_MENU_ITEM (item), m);
+            destroy_menu (m);
+            return TRUE;
         }
     }
 #endif


### PR DESCRIPTION
Before this commit, `handle_menu_item_activate()` would only be called by `handle_key_presses()` for items of a first-level submenu. It would not be called for items of the top-level menu or of a deeper submenu. In particular, in wfplug-menu, the Run and Logout items in the top-level menu could not be activated by navigating to them using arrow keys and hitting Return.

It would seem cleaner to me to use the `"activate"` signal instead of reimplementing handling of the Return key. However, I can't quite oversee the consequences of that, in particular related to long-press support. Furthermore, I know that the maintainer prefers patches from external contributors to be as targeted and as minimal as possible, so it seems to me that the present commit is more likely to get accepted.

I have tested that the Logout and Run dialogs can now be accessed by hitting Return on their top-level menu items. Starting applications from submenus and subsubmenus by hitting Return also works.

As part of the testing, I added a subsubmenu by copying `/etc/xdg/menus/rpd-applications.menu` to `~/.config/menus/` and editing the copy to have a copy of the `Graphics` menu inside the original `Graphics` menu, with the new copy named `Graphics2` and its `<Directory>` tag removed. I'm not sure how the updated menu can be made visible in wfplug-menu. Logging out and back in seems to work.

Issue: https://github.com/raspberrypi-ui/pplug-menu/issues/8